### PR TITLE
feat: implement password change functionality for users

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -15,6 +15,11 @@ const loginSchema = Joi.object({
   password: Joi.string().required(),
 });
 
+const changePasswordSchema = Joi.object({
+  currentPassword: Joi.string().required(),
+  newPassword: Joi.string().min(6).required(),
+});
+
 export class AuthController {
   /**
    * Register a new user
@@ -124,5 +129,56 @@ export class AuthController {
       success: true,
       message: 'Logged out successfully'
     });
+  }
+
+  /**
+   * Change user password
+   */
+  static async changePassword(req: Request, res: Response): Promise<Response> {
+    try {
+      if (!req.user) {
+        return res.status(401).json({
+          success: false,
+          error: { message: 'User not authenticated' }
+        });
+      }
+
+      // Validate request body
+      const { error, value } = changePasswordSchema.validate(req.body);
+      if (error) {
+        return res.status(400).json({
+          success: false,
+          error: { message: error.details[0].message }
+        });
+      }
+
+      await AuthService.changePassword(req.user.id, value);
+
+      return res.json({
+        success: true,
+        message: 'Password changed successfully'
+      });
+    } catch (error: any) {
+      logger.error('Change password error:', error);
+
+      if (error.message.includes('Current password is incorrect')) {
+        return res.status(400).json({
+          success: false,
+          error: { message: 'Current password is incorrect' }
+        });
+      }
+
+      if (error.message.includes('User not found')) {
+        return res.status(404).json({
+          success: false,
+          error: { message: 'User not found' }
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        error: { message: 'Internal server error during password change' }
+      });
+    }
   }
 }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -32,4 +32,11 @@ router.get('/profile', authenticateToken, AuthController.getProfile);
  */
 router.post('/logout', AuthController.logout);
 
+/**
+ * @route PUT /api/auth/change-password
+ * @desc Change user password
+ * @access Private
+ */
+router.put('/change-password', authenticateToken, AuthController.changePassword);
+
 export default router;

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -2,7 +2,7 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { prisma } from '../utils/database';
 import { logger } from '../utils/logger';
-import { RegisterRequest, LoginRequest, AuthResponse } from '../types/auth';
+import { RegisterRequest, LoginRequest, AuthResponse, ChangePasswordRequest } from '../types/auth';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'fallback-secret-change-in-production';
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
@@ -133,5 +133,41 @@ export class AuthService {
         name: true,
       }
     });
+  }
+
+  /**
+   * Change user password
+   */
+  static async changePassword(userId: string, passwordData: ChangePasswordRequest): Promise<void> {
+    const { currentPassword, newPassword } = passwordData;
+
+    // Get user with password
+    const user = await prisma.user.findUnique({
+      where: { id: userId }
+    });
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    // Verify current password
+    const isCurrentPasswordValid = await bcrypt.compare(currentPassword, user.password);
+
+    if (!isCurrentPasswordValid) {
+      throw new Error('Current password is incorrect');
+    }
+
+    // Hash new password
+    const hashedNewPassword = await bcrypt.hash(newPassword, 12);
+
+    // Update password
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        password: hashedNewPassword,
+      }
+    });
+
+    logger.info(`Password changed successfully for user: ${user.email}`);
   }
 }

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -28,6 +28,11 @@ export interface JwtPayload {
   exp: number;
 }
 
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
 export interface AuthenticatedRequest extends Request {
   user?: {
     id: string;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { CreateRecipePage } from './pages/CreateRecipePage';
 import { EditRecipePage } from './pages/EditRecipePage';
 import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
+import { ProfilePage } from './pages/ProfilePage';
 
 function App() {
   return (
@@ -29,6 +30,7 @@ function App() {
             <Route path="/recipes/:id/edit" element={<EditRecipePage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
           </Routes>
         </Layout>
       </Router>

--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/authStore';
-import { Menu, X, ChefHat, User, LogOut } from 'lucide-react';
+import { Menu, X, ChefHat, User, LogOut, Settings } from 'lucide-react';
 
 interface LayoutProps {
   children: ReactNode;
@@ -69,6 +69,14 @@ export const Layout = ({ children }: LayoutProps) => {
                       <User className="h-4 w-4" />
                       <span>Welcome, {user?.name}</span>
                     </div>
+                    <Link
+                      to="/profile"
+                      className="flex items-center space-x-1 text-gray-700 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      aria-label="Profile settings"
+                    >
+                      <Settings className="h-4 w-4" />
+                      <span>Profile</span>
+                    </Link>
                     <button
                       onClick={handleLogout}
                       className="flex items-center space-x-1 text-gray-700 hover:text-red-600 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-500"
@@ -137,6 +145,15 @@ export const Layout = ({ children }: LayoutProps) => {
                   aria-label="View community recipes"
                 >
                   Community Recipes
+                </Link>
+                <Link
+                  to="/profile"
+                  onClick={closeMobileMenu}
+                  className="flex items-center space-x-2 px-3 py-2 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-md text-sm font-medium transition-colors duration-200"
+                  aria-label="Profile settings"
+                >
+                  <Settings className="h-4 w-4" />
+                  <span>Profile</span>
                 </Link>
                 <button
                   onClick={handleLogout}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useAuthStore } from '../store/authStore';
+import { authService } from '../services/auth';
+import { useToast } from '../components/common/Toast';
+
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z.string().min(6, 'New password must be at least 6 characters'),
+  confirmPassword: z.string().min(1, 'Please confirm your new password'),
+}).refine((data) => data.newPassword === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ["confirmPassword"],
+});
+
+type ChangePasswordForm = z.infer<typeof changePasswordSchema>;
+
+export const ProfilePage = () => {
+  const { user } = useAuthStore();
+  const { showToast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ChangePasswordForm>({
+    resolver: zodResolver(changePasswordSchema),
+  });
+
+  const onSubmit = async (data: ChangePasswordForm) => {
+    try {
+      setIsLoading(true);
+      await authService.changePassword({
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      });
+      
+      showToast('Password changed successfully!', 'success');
+      reset();
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.error?.message || 'Failed to change password';
+      showToast(errorMessage, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="text-center">
+          <p className="text-gray-600">Please log in to view your profile.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="bg-white rounded-lg shadow-sm">
+        {/* Profile Header */}
+        <div className="border-b border-gray-200 px-6 py-4">
+          <h1 className="text-2xl font-bold text-gray-900">Profile Settings</h1>
+          <p className="text-gray-600 mt-1">Manage your account settings and preferences</p>
+        </div>
+
+        {/* User Information */}
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Account Information</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Name</label>
+              <p className="mt-1 text-sm text-gray-900">{user.name || 'Not provided'}</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Email</label>
+              <p className="mt-1 text-sm text-gray-900">{user.email}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Change Password Section */}
+        <div className="px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Change Password</h2>
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            {/* Current Password */}
+            <div>
+              <label htmlFor="currentPassword" className="block text-sm font-medium text-gray-700">
+                Current Password
+              </label>
+              <div className="relative mt-1">
+                <input
+                  {...register('currentPassword')}
+                  id="currentPassword"
+                  type={showCurrentPassword ? 'text' : 'password'}
+                  className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                  className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showCurrentPassword ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              {errors.currentPassword && (
+                <p className="mt-1 text-sm text-red-600">{errors.currentPassword.message}</p>
+              )}
+            </div>
+
+            {/* New Password */}
+            <div>
+              <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700">
+                New Password
+              </label>
+              <div className="relative mt-1">
+                <input
+                  {...register('newPassword')}
+                  id="newPassword"
+                  type={showNewPassword ? 'text' : 'password'}
+                  className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowNewPassword(!showNewPassword)}
+                  className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showNewPassword ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              {errors.newPassword && (
+                <p className="mt-1 text-sm text-red-600">{errors.newPassword.message}</p>
+              )}
+            </div>
+
+            {/* Confirm Password */}
+            <div>
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
+                Confirm New Password
+              </label>
+              <div className="relative mt-1">
+                <input
+                  {...register('confirmPassword')}
+                  id="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showConfirmPassword ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              {errors.confirmPassword && (
+                <p className="mt-1 text-sm text-red-600">{errors.confirmPassword.message}</p>
+              )}
+            </div>
+
+            {/* Submit Button */}
+            <div className="pt-4">
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full md:w-auto bg-blue-600 text-white py-2 px-6 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isLoading ? 'Changing Password...' : 'Change Password'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -31,6 +31,11 @@ export interface User {
   createdAt: string;
 }
 
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
 export const authService = {
   // Register new user
   async register(data: RegisterRequest): Promise<AuthResponse> {
@@ -72,5 +77,11 @@ export const authService = {
     const token = this.getToken();
     const user = this.getUser();
     return !!(token && user);
+  },
+
+  // Change password
+  async changePassword(data: ChangePasswordRequest): Promise<{ success: boolean; message: string }> {
+    const response = await api.put('/auth/change-password', data);
+    return response.data;
   },
 };


### PR DESCRIPTION
- Add changePassword endpoint to backend API (/api/auth/change-password)
- Implement ChangePasswordRequest type and validation
- Add changePassword method to AuthService with current password verification
- Create comprehensive ProfilePage component with password change form
- Add Profile navigation link in both desktop and mobile layouts
- Include proper validation, error handling, and user feedback
- Secure implementation requiring current password verification before change

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)